### PR TITLE
Corrected order of arguments

### DIFF
--- a/src/ZF/OAuth2/Adapter/PdoAdapter.php
+++ b/src/ZF/OAuth2/Adapter/PdoAdapter.php
@@ -79,7 +79,7 @@ class PdoAdapter extends OAuth2Pdo
      */
     protected function checkPassword($user, $password)
     {
-        return $this->bcrypt->verify($user['password'], $password);
+        return $this->bcrypt->verify($password, $user['password']);
     }
 
     /**


### PR DESCRIPTION
- Zend\Crypt\Password\Bcrypt::verify() expects arguments in the order
  ($password, $hash); previous code had these backwards (i.e., $hash, $password).
