### PR TITLE
Marshal the OAuth2 Request from the ZF2 request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": ">=5.4.8",
         "bshaffer/oauth2-server-php": "dev-develop",
         "zendframework/zendframework": "~2.3-dev",
-        "zfcampus/zf-api-problem": "~1.0-dev"
+        "zfcampus/zf-api-problem": "~1.0-dev",
+        "zfcampus/zf-content-negotiation": "~1.0-dev"
     },
     "require-dev": {
         "phpunit/PHPUnit": "3.7.*"

--- a/src/ZF/OAuth2/Controller/AuthController.php
+++ b/src/ZF/OAuth2/Controller/AuthController.php
@@ -9,6 +9,7 @@ namespace ZF\OAuth2\Controller;
 use OAuth2\Request as OAuth2Request;
 use OAuth2\Response as OAuth2Response;
 use OAuth2\Server as OAuth2Server;
+use Zend\Http\PhpEnvironment\Request as PhpEnvironmentRequest;
 use Zend\Http\Request as HttpRequest;
 use Zend\Mvc\Controller\AbstractActionController;
 use ZF\ApiProblem\ApiProblem;
@@ -48,7 +49,8 @@ class AuthController extends AbstractActionController
             return $this->getResponse();
         }
 
-        $response = $this->server->handleTokenRequest($this->getOAuth2Request());
+        $oauth2request = $this->getOAuth2Request();
+        $response = $this->server->handleTokenRequest($oauth2request);
         if ($response->isClientError()) {
             $parameters = $response->getParameters();
             $errorUri   = isset($parameters['error_uri']) ? $parameters['error_uri'] : null;
@@ -173,9 +175,28 @@ class AuthController extends AbstractActionController
         $zf2Request = $this->getRequest();
         $headers    = $zf2Request->getHeaders();
 
+        // Marshal content type, so we can seed it into the $_SERVER array
         $contentType = '';
         if ($headers->has('Content-Type')) {
             $contentType = $headers->get('Content-Type')->getFieldValue();
+        }
+
+        // Get $_SERVER superglobal
+        $server = [];
+        if ($zf2Request instanceof PhpEnvironmentRequest) {
+            $server = $zf2Request->getServer()->toArray();
+        } elseif (!empty($_SERVER)) {
+            $server = $_SERVER;
+        }
+        $server['REQUEST_METHOD'] = $zf2Request->getMethod();
+
+        // Seed headers with HTTP auth information
+        $headers = $headers->toArray();
+        if (isset($server['PHP_AUTH_USER'])) {
+            $headers['PHP_AUTH_USER'] = $server['PHP_AUTH_USER'];
+        }
+        if (isset($server['PHP_AUTH_PW'])) {
+            $headers['PHP_AUTH_PW'] = $server['PHP_AUTH_PW'];
         }
 
         return new OAuth2Request(
@@ -184,12 +205,9 @@ class AuthController extends AbstractActionController
             [], // attributes
             [], // cookies
             [], // files
-            [
-                'REQUEST_METHOD' => $zf2Request->getMethod(),
-                'CONTENT_TYPE'   => $contentType,
-            ],
+            $server,
             $zf2Request->getContent(),
-            $headers->toArray()
+            $headers
         );
     }
 

--- a/test/ZFTest/OAuth2/Controller/AuthControllerTest.php
+++ b/test/ZFTest/OAuth2/Controller/AuthControllerTest.php
@@ -29,10 +29,11 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
 
     public function testToken()
     {
-        $_POST['grant_type'] = 'client_credentials';
-        $_SERVER['PHP_AUTH_USER'] = 'testclient';
-        $_SERVER['PHP_AUTH_PW'] = 'testpass';
-        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $request = $this->getRequest();
+        $request->getPost()->set('grant_type', 'client_credentials');
+        $request->getServer()->set('PHP_AUTH_USER', 'testclient');
+        $request->getServer()->set('PHP_AUTH_PW', 'testpass');
+        $request->setMethod('POST');
 
         $this->dispatch('/oauth');
         $this->assertControllerName('ZF\OAuth2\Controller\Auth');
@@ -96,11 +97,12 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
             $code = $matches[1];
         }
         // test get token from authorized code
-        $_POST['grant_type'] = 'authorization_code';
-        $_POST['code'] = $code;
-        $_POST['redirect_uri'] = '/oauth/receivecode';
-        $_SERVER['PHP_AUTH_USER'] = 'testclient';
-        $_SERVER['PHP_AUTH_PW'] = 'testpass';
+        $request = $this->getRequest();
+        $request->getPost()->set('grant_type', 'authorization_code');
+        $request->getPost()->set('code', $code);
+        $request->getPost()->set('redirect_uri', '/oauth/receivecode');
+        $request->getServer()->set('PHP_AUTH_USER', 'testclient');
+        $request->getServer()->set('PHP_AUTH_PW', 'testpass');
 
         $this->dispatch('/oauth');
         $this->assertControllerName('ZF\OAuth2\Controller\Auth');
@@ -120,12 +122,13 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
             $this->markTestSkipped('The allow implicit client mode is disabled');
         }
 
-        $_GET['response_type'] = 'token';
-        $_GET['client_id'] = 'testclient';
-        $_GET['state'] = 'xyz';
-        $_GET['redirect_uri'] = '/oauth/receivecode';
-        $_POST['authorized'] = 'yes';
-        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $request = $this->getRequest();
+        $request->getQuery()->set('response_type', 'token');
+        $request->getQuery()->set('client_id', 'testclient');
+        $request->getQuery()->set('state', 'xyz');
+        $request->getQuery()->set('redirect_uri', '/oauth/receivecode');
+        $request->getPost()->set('authorized', 'yes');
+        $request->setMethod('POST');
 
         $this->dispatch('/oauth/authorize');
         $this->assertTrue($this->getResponse()->isRedirect());
@@ -143,10 +146,11 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
 
     public function testResource()
     {
-        $_POST['grant_type'] = 'client_credentials';
-        $_SERVER['PHP_AUTH_USER'] = 'testclient';
-        $_SERVER['PHP_AUTH_PW'] = 'testpass';
-        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $request = $this->getRequest();
+        $request->getPost()->set('grant_type', 'client_credentials');
+        $request->getServer()->set('PHP_AUTH_USER', 'testclient');
+        $request->getServer()->set('PHP_AUTH_PW', 'testpass');
+        $request->setMethod('POST');
 
         $this->dispatch('/oauth');
         $this->assertControllerName('ZF\OAuth2\Controller\Auth');
@@ -159,10 +163,12 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $token = $response['access_token'];
 
         // test resource through token by POST
-        $_POST['access_token'] = $token;
-        unset($_POST['grant_type']);
-        unset($_SERVER['PHP_AUTH_USER']);
-        unset($_SERVER['PHP_AUTH_PW']);
+        $post = $request->getPost();
+        unset($post['grant_type']);
+        $post->set('access_token', $token);
+        $server = $request->getServer();
+        unset($server['PHP_AUTH_USER']);
+        unset($server['PHP_AUTH_PW']);
 
         $this->dispatch('/oauth/resource');
         $this->assertControllerName('ZF\OAuth2\Controller\Auth');
@@ -174,9 +180,9 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $this->assertEquals('You accessed my APIs!', $response['message']);
 
         // test resource through token by Bearer header
-        $_SERVER['HTTP_AUTHORIZATION'] = "Bearer $token";
-        unset($_POST['access_token']);
-        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $server->set('HTTP_AUTHORIZATION', "Bearer $token");
+        unset($post['access_token']);
+        $request->setMethod('GET');
 
         $this->dispatch('/oauth/resource');
         $this->assertControllerName('ZF\OAuth2\Controller\Auth');

--- a/test/ZFTest/OAuth2/TestAsset/application.config.php
+++ b/test/ZFTest/OAuth2/TestAsset/application.config.php
@@ -2,6 +2,7 @@
 return array(
     // This should be an array of module namespaces used in the application.
     'modules' => array(
+        'ZF\ContentNegotiation',
         'ZF\OAuth2'
     ),
 


### PR DESCRIPTION
- Extracted the method getOAuth2Request(); marshals all values necessary
  for creating a valid OAuth2\Request instance. In particular, it
  ensures that the OAuth2\Request instance is populated from
  content-negotiated values.
