### PR TITLE
Refactor: Splitting up the factory for AuthController into separate fact...

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -51,8 +51,9 @@ return array(
     ),
     'service_manager' => array(
         'factories' => array(
-            'ZF\OAuth2\Adapter\PdoAdapter' => 'ZF\OAuth2\Factory\PdoAdapterFactory',
-            'ZF\OAuth2\Adapter\MongoAdapter' => 'ZF\OAuth2\Factory\MongoAdapterFactory'
+            'ZF\OAuth2\Adapter\PdoAdapter'   => 'ZF\OAuth2\Factory\PdoAdapterFactory',
+            'ZF\OAuth2\Adapter\MongoAdapter' => 'ZF\OAuth2\Factory\MongoAdapterFactory',
+            'ZF\OAuth2\Service\OAuth2Server' => 'ZF\OAuth2\Factory\OAuth2ServerFactory'
         )
     ),
     'view_manager' => array(

--- a/src/ZF/OAuth2/Factory/AuthControllerFactory.php
+++ b/src/ZF/OAuth2/Factory/AuthControllerFactory.php
@@ -9,52 +9,17 @@ namespace ZF\OAuth2\Factory;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\OAuth2\Controller\AuthController;
-use ZF\OAuth2\Controller\Exception;
-use OAuth2\Server as OAuth2Server;
-use OAuth2\GrantType\AuthorizationCode;
-use OAuth2\GrantType\ClientCredentials;
-use OAuth2\GrantType\RefreshToken;
-use OAuth2\GrantType\UserCredentials;
+
 
 class AuthControllerFactory implements FactoryInterface
 {
     /**
      * @param ServiceLocatorInterface $controllers
      * @return AuthController
-     * @throws \ZF\OAuth2\Controller\Exception\RuntimeException
      */
     public function createService(ServiceLocatorInterface $controllers)
     {
         $services = $controllers->getServiceLocator()->get('ServiceManager');
-        $config   = $services->get('Configuration');
-
-        if (!isset($config['zf-oauth2']['storage']) || empty($config['zf-oauth2']['storage'])) {
-            throw new Exception\RuntimeException(
-                'The storage configuration [\'zf-oauth2\'][\'storage\'] for OAuth2 is missing'
-            );
-        }
-
-        $storage = $services->get($config['zf-oauth2']['storage']);
-
-        $enforceState  = isset($config['zf-oauth2']['enforce_state'])  ? $config['zf-oauth2']['enforce_state']  : true;
-        $allowImplicit = isset($config['zf-oauth2']['allow_implicit']) ? $config['zf-oauth2']['allow_implicit'] : false;
-        $accessLifetime = isset($config['zf-oauth2']['access_lifetime']) ? $config['zf-oauth2']['access_lifetime'] : 3600;
-
-        // Pass a storage object or array of storage objects to the OAuth2 server class
-        $server = new OAuth2Server($storage, array('enforce_state' => $enforceState, 'allow_implicit' => $allowImplicit, 'access_lifetime' => $accessLifetime));
-
-        // Add the "Client Credentials" grant type (it is the simplest of the grant types)
-        $server->addGrantType(new ClientCredentials($storage));
-
-        // Add the "Authorization Code" grant type (this is where the oauth magic happens)
-        $server->addGrantType(new AuthorizationCode($storage));
-
-        // Add the "User Credentials" grant type
-        $server->addGrantType(new UserCredentials($storage));
-
-        // Add the "Refresh Token" grant type
-        $server->addGrantType(new RefreshToken($storage));
-
-        return new AuthController($server);
+        return new AuthController($services->get('ZF\OAuth2\Service\OAuth2Server'));
     }
 }

--- a/src/ZF/OAuth2/Factory/OAuth2ServerFactory.php
+++ b/src/ZF/OAuth2/Factory/OAuth2ServerFactory.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\OAuth2\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\OAuth2\Controller\Exception;
+use OAuth2\Server as OAuth2Server;
+use OAuth2\GrantType\AuthorizationCode;
+use OAuth2\GrantType\ClientCredentials;
+use OAuth2\GrantType\RefreshToken;
+use OAuth2\GrantType\UserCredentials;
+
+class OAuth2ServerFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $services
+     * @return OAuth2\Server
+     * @throws \ZF\OAuth2\Controller\Exception\RuntimeException
+     */
+    public function createService(ServiceLocatorInterface $services)
+    {
+        $config   = $services->get('Configuration');
+
+        if (!isset($config['zf-oauth2']['storage']) || empty($config['zf-oauth2']['storage'])) {
+            throw new Exception\RuntimeException(
+                'The storage configuration [\'zf-oauth2\'][\'storage\'] for OAuth2 is missing'
+            );
+        }
+
+        $storage = $services->get($config['zf-oauth2']['storage']);
+
+        $enforceState   = isset($config['zf-oauth2']['enforce_state'])  ? $config['zf-oauth2']['enforce_state']  : true;
+        $allowImplicit  = isset($config['zf-oauth2']['allow_implicit']) ? $config['zf-oauth2']['allow_implicit'] : false;
+        $accessLifetime = isset($config['zf-oauth2']['access_lifetime']) ? $config['zf-oauth2']['access_lifetime'] : 3600;
+
+        // Pass a storage object or array of storage objects to the OAuth2 server class
+        $server = new OAuth2Server($storage, array('enforce_state' => $enforceState, 'allow_implicit' => $allowImplicit, 'access_lifetime' => $accessLifetime));
+
+        // Add the "Client Credentials" grant type (it is the simplest of the grant types)
+        $server->addGrantType(new ClientCredentials($storage));
+
+        // Add the "Authorization Code" grant type (this is where the oauth magic happens)
+        $server->addGrantType(new AuthorizationCode($storage));
+
+        // Add the "User Credentials" grant type
+        $server->addGrantType(new UserCredentials($storage));
+
+        // Add the "Refresh Token" grant type
+        $server->addGrantType(new RefreshToken($storage));
+
+        return $server;
+    }
+}

--- a/test/ZFTest/OAuth2/Factory/AuthControllerFactoryTest.php
+++ b/test/ZFTest/OAuth2/Factory/AuthControllerFactoryTest.php
@@ -28,27 +28,18 @@ class AuthControllerFactoryTest extends AbstractHttpControllerTestCase
      */
     protected $services;
 
-    /**
-     * @expectedException \ZF\OAuth2\Controller\Exception\RuntimeException
-     */
-    public function testExceptionThrownOnMissingStorageClass()
-    {
-        $this->services->setService('Configuration', array());
-        $this->factory->createService($this->controllers);
-    }
+    
 
     public function testControllerCreated()
     {
-        $adapter = $this->getMockBuilder('OAuth2\Storage\Pdo')->disableOriginalConstructor()->getMock();
+        $oauthServer = $this->getMockBuilder('OAuth2\Server')->disableOriginalConstructor()->getMock();
 
-        $this->services->setService('TestAdapter', $adapter);
-        $this->services->setService('Configuration', array(
-            'zf-oauth2' => array(
-                'storage' => 'TestAdapter'
-            )
-        ));
+        $this->services->setService('ZF\OAuth2\Service\OAuth2Server', $oauthServer);
+       
         $controller = $this->factory->createService($this->controllers);
+        
         $this->assertInstanceOf('ZF\OAuth2\Controller\AuthController', $controller);
+        $this->assertEquals(new \ZF\OAuth2\Controller\AuthController($oauthServer), $controller);
     }
 
     protected function setUp()

--- a/test/ZFTest/OAuth2/Factory/OAuth2ServerFactoryTest.php
+++ b/test/ZFTest/OAuth2/Factory/OAuth2ServerFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ */
+
+namespace ZFTest\OAuth2\Factory;
+
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+use ZF\OAuth2\Factory\OAuth2ServerFactory;
+use OAuth2\GrantType\AuthorizationCode;
+use OAuth2\GrantType\ClientCredentials;
+use OAuth2\GrantType\RefreshToken;
+use OAuth2\GrantType\UserCredentials;
+
+class OAuth2ServerFactoryTest extends AbstractHttpControllerTestCase
+{
+
+    /**
+     * @var OAuth2ServerFactory
+     */
+    protected $factory;
+
+    /**
+     * @var ServiceManager
+     */
+    protected $services;
+
+    /**
+     * @expectedException \ZF\OAuth2\Controller\Exception\RuntimeException
+     */
+    public function testExceptionThrownOnMissingStorageClass()
+    {
+        $this->services->setService('Configuration', array());
+        $this->factory->createService($this->services);
+    }
+
+    public function testServiceCreatedWithDefaults()
+    {
+        $adapter = $this->getMockBuilder('OAuth2\Storage\Pdo')->disableOriginalConstructor()->getMock();
+
+        $this->services->setService('TestAdapter', $adapter);
+        $this->services->setService('Configuration', array(
+            'zf-oauth2' => array(
+                'storage' => 'TestAdapter'
+            )
+        ));
+
+        $expectedService = new \OAuth2\Server($adapter, array('enforce_state' => true, 'allow_implicit' => false, 'access_lifetime' => 3600));
+        $expectedService->addGrantType(new ClientCredentials($adapter));
+        $expectedService->addGrantType(new AuthorizationCode($adapter));
+        $expectedService->addGrantType(new UserCredentials($adapter));
+        $expectedService->addGrantType(new RefreshToken($adapter));
+
+        $service = $this->factory->createService($this->services);
+        $this->assertInstanceOf('OAuth2\Server', $service);
+        $this->assertEquals($expectedService, $service);
+    }
+
+    public function testServiceCreatedWithOverriddenValues()
+    {
+        $adapter = $this->getMockBuilder('OAuth2\Storage\Pdo')->disableOriginalConstructor()->getMock();
+
+        $this->services->setService('TestAdapter', $adapter);
+        $this->services->setService('Configuration', array(
+            'zf-oauth2' => array(
+                'storage'        => 'TestAdapter',
+                'enforce_state'  => false,
+                'allow_implicit' => true,
+                'access_lifetime' => 12000,
+            )
+        ));
+
+        $expectedService = new \OAuth2\Server($adapter, array('enforce_state' => false, 'allow_implicit' => true, 'access_lifetime' => 12000));
+        $expectedService->addGrantType(new ClientCredentials($adapter));
+        $expectedService->addGrantType(new AuthorizationCode($adapter));
+        $expectedService->addGrantType(new UserCredentials($adapter));
+        $expectedService->addGrantType(new RefreshToken($adapter));
+
+        $service = $this->factory->createService($this->services);
+        $this->assertInstanceOf('OAuth2\Server', $service);
+        $this->assertEquals($expectedService, $service);
+    }
+
+    protected function setUp()
+    {
+        $this->factory = new OAuth2ServerFactory();
+
+        $this->services = $services = new ServiceManager();
+
+    }
+}


### PR DESCRIPTION
Refactor: Splitting up the factory for AuthController into separate factories for AuthController and OAuth2Server

This pull request replaces PR https://github.com/zfcampus/zf-oauth2/pull/29 as it became out of sync, this one includes the changes from https://github.com/zfcampus/zf-oauth2/pull/28
