### PR TITLE
When calling from apigility skelton php vendor/zfcampus/zf-oauth2/bin/bc...

### DIFF
--- a/bin/bcrypt.php
+++ b/bin/bcrypt.php
@@ -6,6 +6,9 @@
  */
 
 $autoload = realpath(__DIR__ . '/../vendor/autoload.php');
+if (! $autoload) {
+    $autoload = realpath(__DIR__ . '/../../../autoload.php');
+}
 $zf2Env   = "ZF2_PATH";
 
 if (file_exists($autoload)) {


### PR DESCRIPTION
...rypt.php the include will not work and throw exceptions. So this is a fix. Kept the rest for if this is used from somewhere else as a package
