### PR TITLE
Use SMALLINT instead of TINYINT(1)

### DIFF
--- a/data/db_oauth2.sql
+++ b/data/db_oauth2.sql
@@ -44,7 +44,7 @@ CREATE TABLE oauth_scopes (
     type VARCHAR(255) NOT NULL DEFAULT "supported",
     scope VARCHAR(2000),
     client_id VARCHAR (80),
-    is_default TINYINT(1) DEFAULT NULL
+    is_default SMALLINT DEFAULT NULL
 );
 CREATE TABLE oauth_jwt (
     client_id VARCHAR(80) NOT NULL,


### PR DESCRIPTION
Having the datatype TINYINT(1) makes the script incompatible with postgresql. Using SMALLINT instead, and the script works with both mysql and postgresql.
