### PR TITLE
Added the options for client credential and refresh token + fixed unit test  for MongoDb

### DIFF
--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -37,16 +37,22 @@ class OAuth2ServerFactory implements FactoryInterface
         $enforceState   = isset($config['zf-oauth2']['enforce_state'])   ? $config['zf-oauth2']['enforce_state']   : true;
         $allowImplicit  = isset($config['zf-oauth2']['allow_implicit'])  ? $config['zf-oauth2']['allow_implicit']  : false;
         $accessLifetime = isset($config['zf-oauth2']['access_lifetime']) ? $config['zf-oauth2']['access_lifetime'] : 3600;
-
-        // Pass a storage object or array of storage objects to the OAuth2 server class
-        $server = new OAuth2Server($storage, array(
+        $options        = isset($config['zf-oauth2']['options'])         ? $config['zf-oauth2']['options']         : array();
+        $options        = array_merge($options, array(
             'enforce_state'   => $enforceState,
             'allow_implicit'  => $allowImplicit,
             'access_lifetime' => $accessLifetime
         ));
+ 
+        // Pass a storage object or array of storage objects to the OAuth2 server class
+        $server = new OAuth2Server($storage, $options);
 
+        $clientOptions = array();
+        if (isset($options['allow_credentials_in_request_body'])) {
+            $clientOptions['allow_credentials_in_request_body'] = $options['allow_credentials_in_request_body'];
+        }
         // Add the "Client Credentials" grant type (it is the simplest of the grant types)
-        $server->addGrantType(new ClientCredentials($storage));
+        $server->addGrantType(new ClientCredentials($storage, $clientOptions));
 
         // Add the "Authorization Code" grant type (this is where the oauth magic happens)
         $server->addGrantType(new AuthorizationCode($storage));
@@ -54,8 +60,15 @@ class OAuth2ServerFactory implements FactoryInterface
         // Add the "User Credentials" grant type
         $server->addGrantType(new UserCredentials($storage));
 
+        $refreshOptions = array();
+        if (isset($options['always_issue_new_refresh_token'])) {
+            $refreshOptions['always_issue_new_refresh_token'] = $options['always_issue_new_refresh_token'];
+        }
+        if (isset($options['refresh_token_lifetime'])) {
+            $refreshOptions['refresh_token_lifetime'] = $options['refresh_token_lifetime'];
+        }
         // Add the "Refresh Token" grant type
-        $server->addGrantType(new RefreshToken($storage));
+        $server->addGrantType(new RefreshToken($storage, $refreshOptions));
 
         return $server;
     }

--- a/test/Controller/AuthControllerWithMongoAdapterTest.php
+++ b/test/Controller/AuthControllerWithMongoAdapterTest.php
@@ -18,8 +18,7 @@ class AuthControllerWithMongoAdapterTest extends AbstractHttpControllerTestCase
     public function setUp()
     {
         if (!extension_loaded('mongo')) {
-            $this->markTestSkipped('The Mongo extension is not available.'
-            );
+            $this->markTestSkipped('The Mongo extension is not available.');
         }
 
         $this->setApplicationConfig(
@@ -28,7 +27,11 @@ class AuthControllerWithMongoAdapterTest extends AbstractHttpControllerTestCase
 
         parent::setUp();
 
-        $client   = new \MongoClient("mongodb://127.0.0.1:27017");
+        try {
+            $client = new \MongoClient("mongodb://127.0.0.1:27017");
+        } catch (\MongoConnectionException $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
         $this->db = $client->selectDB('zf_oauth2_test');
         $this->db->oauth_clients->insert(array(
             'client_id'     => 'testclient',


### PR DESCRIPTION
I added the options for client credential and refresh token grant types. In particular, the refresh token option `always_issue_new_refresh_token` set to true generate a new refresh_token on each refresh call.
I added the `options` key in the `zf-oauth2` configuration, to be able to pass all the [parameters of the OAuth2\Server](https://github.com/bshaffer/oauth2-server-php/blob/develop/src/OAuth2/Server.php#L115-L128) class.
I also fixed the unit test for the MongoDb adapter, now if MongoDb is not running it does not report errors.
