### PR TITLE
Ensure bodyParams is an array before creating request

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -199,6 +199,13 @@ class AuthController extends AbstractActionController
             $headers['PHP_AUTH_PW'] = $server['PHP_AUTH_PW'];
         }
 
+        // Ensure the bodyParams are passed as an array
+        if (!is_array($this->bodyParams())) {
+            $bodyParams = array();
+        } else {
+            $bodyParams = $this->bodyParams();
+        }
+
         return new OAuth2Request(
             $zf2Request->getQuery()->toArray(),
             $this->bodyParams(),


### PR DESCRIPTION
We are using several pieces from Apigility to build our internal API and I am seeing this error every once in a while on NewRelic.

While this patch dosent seem to get to the root cause, it does let the application continue on.

Error: Argument 2 passed to OAuth2\Request::__construct() must be of the type array, null given, called in /var/www/web-site/releases/20140805145036/vendor/zfcampus/zf-oauth2/src/Controller/AuthController.php on line 211 and defined
