### PR TITLE
Use content negotiation in AuthController

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -57,6 +57,10 @@ return array(
         )
     ),
     'view_manager' => array(
+        'template_map' => array(
+            'oauth/authorize'    => __DIR__ . '/../view/zf/auth/authorize.phtml',
+            'oauth/receive-code' => __DIR__ . '/../view/zf/auth/receive-code.phtml',
+        ),
         'template_path_stack' => array(
             __DIR__ . '/../view',
         ),

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -121,7 +121,7 @@ class AuthController extends AbstractActionController
         if (empty($authorized)) {
             $clientId = $request->query('client_id', false);
             $view = new ViewModel(array('clientId' => $clientId));
-            $view->setTemplate('zf/auth/authorize');
+            $view->setTemplate('oauth/authorize');
             return $view;
         }
 
@@ -155,7 +155,7 @@ class AuthController extends AbstractActionController
         $view = new ViewModel(array(
             'code' => $code
         ));
-        $view->setTemplate('zf/auth/receive-code');
+        $view->setTemplate('oauth/receive-code');
         return $view;
     }
 


### PR DESCRIPTION
- Added zf-content-negotiation rules for AuthController in
  configuration.
- Modified controller to return a zf-content-negotiation ViewModel from
  the authorize and receive-code actions, and set that up to specify the
  template properly (and as documented).
