### PR TITLE
Merge ['zf-oauth']['options'] the correct way around

### DIFF
--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -38,11 +38,11 @@ class OAuth2ServerFactory implements FactoryInterface
         $allowImplicit  = isset($config['zf-oauth2']['allow_implicit'])  ? $config['zf-oauth2']['allow_implicit']  : false;
         $accessLifetime = isset($config['zf-oauth2']['access_lifetime']) ? $config['zf-oauth2']['access_lifetime'] : 3600;
         $options        = isset($config['zf-oauth2']['options'])         ? $config['zf-oauth2']['options']         : array();
-        $options        = array_merge($options, array(
+        $options        = array_merge(array(
             'enforce_state'   => $enforceState,
             'allow_implicit'  => $allowImplicit,
             'access_lifetime' => $accessLifetime
-        ));
+        ), $options);
 
         // Pass a storage object or array of storage objects to the OAuth2 server class
         $server = new OAuth2Server($storage, $options);

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -83,6 +83,33 @@ class OAuth2ServerFactoryTest extends AbstractHttpControllerTestCase
         $this->assertEquals($expectedService, $service);
     }
 
+    public function testServiceCreatedWithOverriddenValuesInOptionsSubArray()
+    {
+        $adapter = $this->getMockBuilder('OAuth2\Storage\Pdo')->disableOriginalConstructor()->getMock();
+
+        $this->services->setService('TestAdapter', $adapter);
+        $this->services->setService('Config', array(
+            'zf-oauth2' => array(
+                'storage' => 'TestAdapter',
+                'options' => array(
+                    'enforce_state'   => false,
+                    'allow_implicit'  => true,
+                    'access_lifetime' => 12000,
+                ),
+            )
+        ));
+
+        $expectedService = new \OAuth2\Server($adapter, array('enforce_state' => false, 'allow_implicit' => true, 'access_lifetime' => 12000));
+        $expectedService->addGrantType(new ClientCredentials($adapter));
+        $expectedService->addGrantType(new AuthorizationCode($adapter));
+        $expectedService->addGrantType(new UserCredentials($adapter));
+        $expectedService->addGrantType(new RefreshToken($adapter));
+
+        $service = $this->factory->createService($this->services);
+        $this->assertInstanceOf('OAuth2\Server', $service);
+        $this->assertEquals($expectedService, $service);
+    }
+
     protected function setUp()
     {
         $this->factory = new OAuth2ServerFactory();


### PR DESCRIPTION
If I define 'enforce_state', 'allow_implicit' or 'access_lifetime' in
the 'options' sub-array, they should work. i.e. setting these three
settings in the top level 'zf-oauth2' setting is a shortcut.
