### PR TITLE
Redirecting to the URI callback when user deny the authorization.

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -130,11 +130,9 @@ class AuthController extends AbstractActionController
 
         $is_authorized = ($authorized === 'yes');
         $this->server->handleAuthorizeRequest($request, $response, $is_authorized, $this->getRequest()->getQuery('user_id', null));
-        if ($is_authorized) {
-            $redirect = $response->getHttpHeader('Location');
-            if (!empty($redirect)) {
-                return $this->redirect()->toUrl($redirect);
-            }
+        $redirect = $response->getHttpHeader('Location');
+        if (!empty($redirect)) {
+            return $this->redirect()->toUrl($redirect);
         }
 
         $parameters = $response->getParameters();


### PR DESCRIPTION
Using Authorization Code Grant Type.
When the user deny the authorization, it is not redirecting back to the URI callback of the OAuth Client.
This pull request fix it and now it redirect to the URI callback whenever the user allows or deny the authorization.

If there is no URI callback configured, it return an ApiProblem (as it always was).
