### PR TITLE
add oauth2 response format

### DIFF
--- a/bin/phpcs.sh
+++ b/bin/phpcs.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
-SCRIPT_PATH=$(readlink -f $0)
-WORKDIR=$(dirname $SCRIPT_PATH)
-WORKDIR=$(dirname $WORKDIR)
+SCRIPT_PATH=$(php -r "echo readlink('${0}');")
+WORKDIR=$(php -r "echo dirname(dirname('${SCRIPT_PATH}'));")
 
 PHP_VERSION=$(php -v | grep '^PHP [[:digit:]].[[:digit:]]' | cut -d ' ' -f2)
 IS_PHP_5_3=$(php -r "echo version_compare('${PHP_VERSION}', '5.4.0');")

--- a/bin/phpcs.sh
+++ b/bin/phpcs.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-SCRIPT_PATH=$(php -r "echo readlink('${0}');")
-WORKDIR=$(php -r "echo dirname(dirname('${SCRIPT_PATH}'));")
+SCRIPT_PATH=$(readlink -f $0)
+WORKDIR=$(dirname $SCRIPT_PATH)
+WORKDIR=$(dirname $WORKDIR)
 
 PHP_VERSION=$(php -v | grep '^PHP [[:digit:]].[[:digit:]]' | cut -d ' ' -f2)
 IS_PHP_5_3=$(php -r "echo version_compare('${PHP_VERSION}', '5.4.0');")

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -78,6 +78,8 @@ return array(
          *       // see https://github.com/bshaffer/oauth2-server-php/blob/develop/src/OAuth2/Storage/Pdo.php#L57-L66
          *   ]
          */
+        'api_problem_error_response' => true, // if true, client errors is returned in application/problem+json content type,
+                                              // otherwise in format from oauth2 specification (default: true)
     ),
     'zf-content-negotiation' => array(
         'ZF\OAuth2\Controller\Auth' => array(

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -24,6 +24,11 @@ class AuthController extends AbstractActionController
     protected $server;
 
     /**
+     * @var boolean
+     */
+    protected $apiProblemErrorResponse = true;
+
+    /**
      * Constructor
      *
      * @param $server OAuth2Server
@@ -31,6 +36,22 @@ class AuthController extends AbstractActionController
     public function __construct(OAuth2Server $server)
     {
         $this->server = $server;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isApiProblemErrorResponse()
+    {
+        return $this->apiProblemErrorResponse;
+    }
+
+    /**
+     * @param boolean $apiProblemErrorResponse
+     */
+    public function setApiProblemErrorResponse($apiProblemErrorResponse)
+    {
+        $this->apiProblemErrorResponse = $apiProblemErrorResponse;
     }
 
     /**
@@ -52,21 +73,11 @@ class AuthController extends AbstractActionController
 
         $oauth2request = $this->getOAuth2Request();
         $response = $this->server->handleTokenRequest($oauth2request);
-        if ($response->isClientError()) {
-            $parameters       = $response->getParameters();
-            $errorUri         = isset($parameters['error_uri'])         ? $parameters['error_uri']         : null;
-            $error            = isset($parameters['error'])             ? $parameters['error']             : null;
-            $errorDescription = isset($parameters['error_description']) ? $parameters['error_description'] : null;
 
-            return new ApiProblemResponse(
-                new ApiProblem(
-                    $response->getStatusCode(),
-                    $errorDescription,
-                    $errorUri,
-                    $error
-                )
-            );
+        if ($response->isClientError()) {
+            return $this->getErrorResponse($response);
         }
+
         return $this->setHttpResponse($response);
     }
 
@@ -78,17 +89,9 @@ class AuthController extends AbstractActionController
         // Handle a request for an OAuth2.0 Access Token and send the response to the client
         if (!$this->server->verifyResourceRequest($this->getOAuth2Request())) {
             $response   = $this->server->getResponse();
-            $parameters = $response->getParameters();
-            $errorUri   = isset($parameters['error_uri']) ? $parameters['error_uri'] : null;
-            return new ApiProblemResponse(
-                new ApiProblem(
-                    $response->getStatusCode(),
-                    $parameters['error_description'],
-                    $errorUri,
-                    $parameters['error']
-                )
-            );
+            return $this->getApiProblemResponse($response);
         }
+
         $httpResponse = $this->getResponse();
         $httpResponse->setStatusCode(200);
         $httpResponse->getHeaders()->addHeaders(array('Content-type' => 'application/json'));
@@ -107,17 +110,10 @@ class AuthController extends AbstractActionController
         $response = new OAuth2Response();
 
         // validate the authorize request
-        if (!$this->server->validateAuthorizeRequest($request, $response)) {
-            $parameters = $response->getParameters();
-            $errorUri   = isset($parameters['error_uri']) ? $parameters['error_uri'] : null;
-            return new ApiProblemResponse(
-                new ApiProblem(
-                    $response->getStatusCode(),
-                    $parameters['error_description'],
-                    $errorUri,
-                    $parameters['error']
-                )
-            );
+        $isValid = $this->server->validateAuthorizeRequest($request, $response);
+
+        if (!$isValid) {
+            return $this->getErrorResponse($response);
         }
 
         $authorized = $request->request('authorized', false);
@@ -141,16 +137,7 @@ class AuthController extends AbstractActionController
             return $this->redirect()->toUrl($redirect);
         }
 
-        $parameters = $response->getParameters();
-        $errorUri   = isset($parameters['error_uri']) ? $parameters['error_uri'] : null;
-        return new ApiProblemResponse(
-            new ApiProblem(
-                $response->getStatusCode(),
-                $parameters['error_description'],
-                $errorUri,
-                $parameters['error']
-            )
-        );
+        return $this->getErrorResponse($response);
     }
 
     /**
@@ -164,6 +151,42 @@ class AuthController extends AbstractActionController
         ));
         $view->setTemplate('oauth/receive-code');
         return $view;
+    }
+
+    /**
+     * @param OAuth2Response $response
+     * @return \ZF\ApiProblem\ApiProblemResponse|\Zend\Stdlib\ResponseInterface
+     */
+    protected function getErrorResponse(OAuth2Response $response)
+    {
+        if ($this->isApiProblemErrorResponse()) {
+            return $this->getApiProblemResponse($response);
+        } else {
+            return $this->setHttpResponse($response);
+        }
+    }
+
+    /**
+     * Map OAuth2Response to ApiProblemResponse
+     *
+     * @param OAuth2Response $response
+     * @return ApiProblemResponse
+     */
+    protected function getApiProblemResponse(OAuth2Response $response)
+    {
+        $parameters       = $response->getParameters();
+        $errorUri         = isset($parameters['error_uri'])         ? $parameters['error_uri']         : null;
+        $error            = isset($parameters['error'])             ? $parameters['error']             : null;
+        $errorDescription = isset($parameters['error_description']) ? $parameters['error_description'] : null;
+
+        return new ApiProblemResponse(
+            new ApiProblem(
+                $response->getStatusCode(),
+                $errorDescription,
+                $errorUri,
+                $error
+            )
+        );
     }
 
     /**
@@ -209,6 +232,9 @@ class AuthController extends AbstractActionController
         }
         if (isset($server['PHP_AUTH_PW'])) {
             $headers['PHP_AUTH_PW'] = $server['PHP_AUTH_PW'];
+        }
+        if (isset($server['HTTP_AUTHORIZATION'])) {
+            $headers['AUTHORIZATION'] = $server['HTTP_AUTHORIZATION'];
         }
 
         // Ensure the bodyParams are passed as an array

--- a/src/Factory/AuthControllerFactory.php
+++ b/src/Factory/AuthControllerFactory.php
@@ -19,6 +19,13 @@ class AuthControllerFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $controllers)
     {
         $services = $controllers->getServiceLocator()->get('ServiceManager');
-        return new AuthController($services->get('ZF\OAuth2\Service\OAuth2Server'));
+        $authController = new AuthController($services->get('ZF\OAuth2\Service\OAuth2Server'));
+
+        $config  = $services->get('Config');
+        $apiProblemErrorResponse = isset($config['zf-oauth2']['api_problem_error_response']) && $config['zf-oauth2']['api_problem_error_response'] === true;
+
+        $authController->setApiProblemErrorResponse($apiProblemErrorResponse);
+
+        return $authController;
     }
 }

--- a/src/Factory/AuthControllerFactory.php
+++ b/src/Factory/AuthControllerFactory.php
@@ -22,7 +22,8 @@ class AuthControllerFactory implements FactoryInterface
         $authController = new AuthController($services->get('ZF\OAuth2\Service\OAuth2Server'));
 
         $config  = $services->get('Config');
-        $apiProblemErrorResponse = isset($config['zf-oauth2']['api_problem_error_response']) && $config['zf-oauth2']['api_problem_error_response'] === true;
+        $apiProblemErrorResponse = isset($config['zf-oauth2']['api_problem_error_response'])
+            && $config['zf-oauth2']['api_problem_error_response'] === true;
 
         $authController->setApiProblemErrorResponse($apiProblemErrorResponse);
 

--- a/test/Controller/AuthControllerTest.php
+++ b/test/Controller/AuthControllerTest.php
@@ -45,6 +45,51 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $this->assertTrue(!empty($response['token_type']));
     }
 
+    public function testTokenErrorIsApiProblem()
+    {
+        $request = $this->getRequest();
+        $request->getPost()->set('grant_type', 'fake_grant_type');
+        $request->getServer()->set('PHP_AUTH_USER', 'testclient');
+        $request->getServer()->set('PHP_AUTH_PW', 'testpass');
+        $request->setMethod('POST');
+
+        $this->dispatch('/oauth');
+        $this->assertControllerName('ZF\OAuth2\Controller\Auth');
+        $this->assertActionName('token');
+        $this->assertResponseStatusCode(400);
+
+        $headers = $this->getResponse()->getHeaders();
+        $this->assertEquals('application/problem+json', $headers->get('content-type')->getFieldValue());
+
+        $response = json_decode($this->getResponse()->getContent(), true);
+        $this->assertEquals('unsupported_grant_type', $response['title']);
+        $this->assertEquals('Grant type "fake_grant_type" not supported', $response['detail']);
+        $this->assertEquals('400', $response['status']);
+    }
+
+    public function testTokenErrorIsOAuth2Format()
+    {
+        $request = $this->getRequest();
+        $request->getPost()->set('grant_type', 'fake_grant_type');
+        $request->getServer()->set('PHP_AUTH_USER', 'testclient');
+        $request->getServer()->set('PHP_AUTH_PW', 'testpass');
+        $request->setMethod('POST');
+
+        $this->setIsOAuth2FormatResponse();
+
+        $this->dispatch('/oauth');
+        $this->assertControllerName('ZF\OAuth2\Controller\Auth');
+        $this->assertActionName('token');
+        $this->assertResponseStatusCode(400);
+
+        $headers = $this->getResponse()->getHeaders();
+        $this->assertEquals('application/json', $headers->get('content-type')->getFieldValue());
+
+        $response = json_decode($this->getResponse()->getContent(), true);
+        $this->assertEquals('unsupported_grant_type', $response['error']);
+        $this->assertEquals('Grant type "fake_grant_type" not supported', $response['error_description']);
+    }
+
     public function testAuthorizeForm()
     {
         $_GET['response_type'] = 'code';
@@ -59,7 +104,7 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $this->assertXpathQuery('//form/input[@name="authorized" and @value="no"]');
     }
 
-    public function testAuthorizeErrorParam()
+    public function testAuthorizeParamErrorIsApiProblem()
     {
         $this->dispatch('/oauth/authorize');
 
@@ -74,6 +119,24 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $this->assertEquals('invalid_client', $response['title']);
         $this->assertEquals('No client id supplied', $response['detail']);
         $this->assertEquals('400', $response['status']);
+    }
+
+    public function testAuthorizeParamErrorIsOAuth2Format()
+    {
+        $this->setIsOAuth2FormatResponse();
+
+        $this->dispatch('/oauth/authorize');
+
+        $this->assertControllerName('ZF\OAuth2\Controller\Auth');
+        $this->assertActionName('authorize');
+        $this->assertResponseStatusCode(400);
+
+        $headers = $this->getResponse()->getHeaders();
+        $this->assertEquals('application/json', $headers->get('content-type')->getFieldValue());
+
+        $response = json_decode($this->getResponse()->getContent(), true);
+        $this->assertEquals('invalid_client', $response['error']);
+        $this->assertEquals('No client id supplied', $response['error_description']);
     }
 
     public function testAuthorizeCode()
@@ -174,6 +237,7 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(200);
 
         $response = json_decode($this->getResponse()->getContent(), true);
+
         $this->assertTrue($response['success']);
         $this->assertEquals('You accessed my APIs!', $response['message']);
 
@@ -190,5 +254,16 @@ class AuthControllerTest extends AbstractHttpControllerTestCase
         $response = json_decode($this->getResponse()->getContent(), true);
         $this->assertTrue($response['success']);
         $this->assertEquals('You accessed my APIs!', $response['message']);
+    }
+
+    protected function setIsOAuth2FormatResponse()
+    {
+        $serviceManager = $this->getApplication()->getServiceManager();
+
+        $config = $serviceManager->get('Config');
+        $config['zf-oauth2']['api_problem_error_response'] = false;
+
+        $serviceManager->setAllowOverride(true);
+        $serviceManager->setService('Config', $config);
     }
 }

--- a/test/Factory/AuthControllerFactoryTest.php
+++ b/test/Factory/AuthControllerFactoryTest.php
@@ -48,6 +48,8 @@ class AuthControllerFactoryTest extends AbstractHttpControllerTestCase
 
         $this->services = $services = new ServiceManager();
 
+        $this->services->setService('Config', array());
+
         $this->controllers = $controllers = new ControllerManager();
         $controllers->setServiceLocator(new ServiceManager());
         $controllers->getServiceLocator()->setService('ServiceManager', $services);

--- a/test/Factory/AuthControllerFactoryTest.php
+++ b/test/Factory/AuthControllerFactoryTest.php
@@ -48,7 +48,11 @@ class AuthControllerFactoryTest extends AbstractHttpControllerTestCase
 
         $this->services = $services = new ServiceManager();
 
-        $this->services->setService('Config', array());
+        $this->services->setService('Config', array(
+            'zf-oauth2' => array(
+                'api_problem_error_response' => true,
+            ),
+        ));
 
         $this->controllers = $controllers = new ControllerManager();
         $controllers->setServiceLocator(new ServiceManager());


### PR DESCRIPTION
resolve #71 

add oauth2 response format configurable, default api problem is set for BC.  
fix bug with lack of mapping AUTHORIZATION header