### PR TITLE
Fixes #66, a bug with null bodyParams not being handled.

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -216,7 +216,7 @@ class AuthController extends AbstractActionController
 
         return new OAuth2Request(
             $zf2Request->getQuery()->toArray(),
-            $this->bodyParams(),
+            $bodyParams,
             array(), // attributes
             array(), // cookies
             array(), // files


### PR DESCRIPTION
Without this change, some requests cause an `ErrorException` to be thrown, saying:
> Argument 2 passed to OAuth2\\Request::__construct() must be of the type array, null given.