### PR TITLE
Return same instance of server on multiple factory invocations

### DIFF
--- a/src/Factory/OAuth2ServerInstanceFactory.php
+++ b/src/Factory/OAuth2ServerInstanceFactory.php
@@ -27,6 +27,11 @@ class OAuth2ServerInstanceFactory
     private $services;
 
     /**
+     * @var OAuth2Server
+     */
+    private $server;
+
+    /**
      * @var array $config Configuration to use when creating the instance.
      * @var ServiceLocatorInterface $services ServiceLocator for retrieving storage adapters.
      */
@@ -43,6 +48,10 @@ class OAuth2ServerInstanceFactory
      */
     public function __invoke()
     {
+        if ($this->server) {
+            return $this->server;
+        }
+
         $config = $this->config;
 
         if (!isset($config['storage']) || empty($config['storage'])) {
@@ -131,6 +140,6 @@ class OAuth2ServerInstanceFactory
             $server->addGrantType(new RefreshToken($server->getStorage('refresh_token'), $refreshOptions));
         }
 
-        return $server;
+        return $this->server = $server;
     }
 }

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -26,6 +26,12 @@ class OAuth2ServerFactoryTest extends AbstractHttpControllerTestCase
      */
     protected $services;
 
+    protected function setUp()
+    {
+        $this->factory = new OAuth2ServerFactory();
+        $this->services = $services = new ServiceManager();
+    }
+
     /**
      * @expectedException \ZF\OAuth2\Controller\Exception\RuntimeException
      */
@@ -264,9 +270,25 @@ class OAuth2ServerFactoryTest extends AbstractHttpControllerTestCase
         $this->assertEquals($expectedService, $server);
     }
 
-    protected function setUp()
+    public function testSubsequentCallsReturnTheSameInstance()
     {
-        $this->factory = new OAuth2ServerFactory();
-        $this->services = $services = new ServiceManager();
+        $adapter = $this->getMockBuilder('OAuth2\Storage\Pdo')->disableOriginalConstructor()->getMock();
+        $this->services->setService('TestAdapter', $adapter);
+        $this->services->setService('Config', array(
+            'zf-oauth2' => array(
+                'storage' => 'TestAdapter',
+                'grant_types' => array(
+                    'client_credentials' => true,
+                    'authorization_code' => true,
+                    'password'           => true,
+                    'refresh_token'      => true,
+                    'jwt'                => true,
+                ),
+            ),
+        ));
+
+        $factory = $this->factory->createService($this->services);
+        $server  = $factory();
+        $this->assertSame($server, $factory());
     }
 }


### PR DESCRIPTION
Updates OAuth2ServerInstanceFactory to cache the generated server
instance, and return the same instance on subsequent requests.

See zfcampus/zf-mvc-auth#70 for details.