### PR TITLE
Add support for the new 'unset_refresh_token_after_use' config option

### DIFF
--- a/src/Factory/OAuth2ServerInstanceFactory.php
+++ b/src/Factory/OAuth2ServerInstanceFactory.php
@@ -135,6 +135,9 @@ class OAuth2ServerInstanceFactory
             if (isset($options['refresh_token_lifetime'])) {
                 $refreshOptions['refresh_token_lifetime'] = $options['refresh_token_lifetime'];
             }
+            if (isset($options['unset_refresh_token_after_use'])) {
+                $refreshOptions['unset_refresh_token_after_use'] = $options['unset_refresh_token_after_use'];
+            }
 
             // Add the "Refresh Token" grant type
             $server->addGrantType(new RefreshToken($server->getStorage('refresh_token'), $refreshOptions));


### PR DESCRIPTION
oauth2-server-php 1.7.0 added this new option for refresh_token grants and sets it false by default. Sadly our applications need it set by default, so we needed this option.

I can imagine this will probably affect other users, so it might be cool to add the option.