### PR TITLE
Remove unused refresh_token_lifetime option when adding RefreshToken GrantType

### DIFF
--- a/src/Factory/OAuth2ServerInstanceFactory.php
+++ b/src/Factory/OAuth2ServerInstanceFactory.php
@@ -132,9 +132,6 @@ class OAuth2ServerInstanceFactory
             if (isset($options['always_issue_new_refresh_token'])) {
                 $refreshOptions['always_issue_new_refresh_token'] = $options['always_issue_new_refresh_token'];
             }
-            if (isset($options['refresh_token_lifetime'])) {
-                $refreshOptions['refresh_token_lifetime'] = $options['refresh_token_lifetime'];
-            }
 
             // Add the "Refresh Token" grant type
             $server->addGrantType(new RefreshToken($server->getStorage('refresh_token'), $refreshOptions));


### PR DESCRIPTION
The "refresh_token_lifetime" must be supplied when creating the OAuth2\Server and is never used within the RefreshToken GrantType