### PR TITLE
add custom grant type in config

### DIFF
--- a/src/Factory/OAuth2ServerInstanceFactory.php
+++ b/src/Factory/OAuth2ServerInstanceFactory.php
@@ -111,13 +111,11 @@ class OAuth2ServerInstanceFactory
 
             // Add the "Client Credentials" grant type (it is the simplest of the grant types)
             $server->addGrantType(new ClientCredentials($server->getStorage('client_credentials'), $clientOptions));
-            unset($availableGrantTypes['client_credentials']);
         }
 
         if (isset($availableGrantTypes['authorization_code']) && $availableGrantTypes['authorization_code'] === true) {
             // Add the "Authorization Code" grant type (this is where the oauth magic happens)
             $server->addGrantType(new AuthorizationCode($server->getStorage('authorization_code')));
-            unset($availableGrantTypes['authorization_code']);
         }
 
         if (isset($availableGrantTypes['password']) && $availableGrantTypes['password'] === true) {
@@ -128,7 +126,6 @@ class OAuth2ServerInstanceFactory
         if (isset($availableGrantTypes['jwt']) && $availableGrantTypes['jwt'] === true) {
             // Add the "JWT Bearer" grant type
             $server->addGrantType(new JwtBearer($server->getStorage('jwt_bearer'), $audience));
-            unset($availableGrantTypes['jwt']);
         }
 
         if (isset($availableGrantTypes['refresh_token']) && $availableGrantTypes['refresh_token'] === true) {
@@ -142,18 +139,17 @@ class OAuth2ServerInstanceFactory
 
             // Add the "Refresh Token" grant type
             $server->addGrantType(new RefreshToken($server->getStorage('refresh_token'), $refreshOptions));
-            unset($availableGrantTypes['refresh_token']);
         }
-
+        
         // Add custom grant type from the service locator
-        if (is_array($availableGrantTypes) && !empty($availableGrantTypes)) {
-            foreach ($availableGrantTypes as $grantType) {
-                if ($this->services->has($grantType)) {
-                    $server->addGrantType($this->services->get($grantType));
+        if (isset($availableGrantTypes['custom_grant_types']) && is_array($availableGrantTypes['custom_grant_types'])) {
+            foreach ($availableGrantTypes['custom_grant_types'] as $grantKey => $grantType) {
+                if ($services->has($grantType)) {
+                    $server->addGrantType($services->get($grantType, $grantKey));
                 }
             }
         }
-
+        
         return $this->server = $server;
     }
 }

--- a/src/Factory/OAuth2ServerInstanceFactory.php
+++ b/src/Factory/OAuth2ServerInstanceFactory.php
@@ -111,11 +111,13 @@ class OAuth2ServerInstanceFactory
 
             // Add the "Client Credentials" grant type (it is the simplest of the grant types)
             $server->addGrantType(new ClientCredentials($server->getStorage('client_credentials'), $clientOptions));
+            unset($availableGrantTypes['client_credentials']);
         }
 
         if (isset($availableGrantTypes['authorization_code']) && $availableGrantTypes['authorization_code'] === true) {
             // Add the "Authorization Code" grant type (this is where the oauth magic happens)
             $server->addGrantType(new AuthorizationCode($server->getStorage('authorization_code')));
+            unset($availableGrantTypes['authorization_code']);
         }
 
         if (isset($availableGrantTypes['password']) && $availableGrantTypes['password'] === true) {
@@ -126,6 +128,7 @@ class OAuth2ServerInstanceFactory
         if (isset($availableGrantTypes['jwt']) && $availableGrantTypes['jwt'] === true) {
             // Add the "JWT Bearer" grant type
             $server->addGrantType(new JwtBearer($server->getStorage('jwt_bearer'), $audience));
+            unset($availableGrantTypes['jwt']);
         }
 
         if (isset($availableGrantTypes['refresh_token']) && $availableGrantTypes['refresh_token'] === true) {
@@ -139,6 +142,16 @@ class OAuth2ServerInstanceFactory
 
             // Add the "Refresh Token" grant type
             $server->addGrantType(new RefreshToken($server->getStorage('refresh_token'), $refreshOptions));
+            unset($availableGrantTypes['refresh_token']);
+        }
+
+        // Add custom grant type from the service locator
+        if (is_array($availableGrantTypes) && !empty($availableGrantTypes)) {
+            foreach ($availableGrantTypes as $grantType) {
+                if ($this->services->has($grantType)) {
+                    $server->addGrantType($this->services->get($grantType));
+                }
+            }
         }
 
         return $this->server = $server;


### PR DESCRIPTION
Hi,
I create a simple PR with no BC break for grant type. The idea behind this PR is to create custom grant type from config using the service locator.

The idea come from this discussion : https://github.com/bshaffer/oauth2-server-php/issues/627. It's also related to this issue : https://github.com/zfcampus/zf-oauth2/pull/70

@weierophinney, @michalkopacz, @nesinervink, what do you think about this change?