### PR TITLE
Removed typo on line 55, changed this->$userId to $this->userId

### DIFF
--- a/src/Provider/UserId/AuthenticationService.php
+++ b/src/Provider/UserId/AuthenticationService.php
@@ -52,7 +52,7 @@ class AuthenticationService implements UserIdProviderInterface
 
         if (is_object($identity)) {
             if (property_exists($identity, $this->userId)) {
-                return $identity->{$this->$userId};
+                return $identity->{$this->userId};
             }
 
             $method = "get" . ucfirst($this->userId);


### PR DESCRIPTION
An error is thrown due to the type on line 55. 

The typo results in the following error:

Undefined variable: userId in /var/www/cloud/vendor/zfcampus/zf-oauth2/src/Provider/UserId/AuthenticationService.php on line 55