### PR TITLE
resolve #133 #131

### DIFF
--- a/src/Factory/AuthControllerFactory.php
+++ b/src/Factory/AuthControllerFactory.php
@@ -10,6 +10,7 @@ use OAuth2\Server as OAuth2Server;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\OAuth2\Controller\AuthController;
+use Zend\ServiceManager\ServiceManager;
 
 class AuthControllerFactory implements FactoryInterface
 {
@@ -19,7 +20,7 @@ class AuthControllerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $controllers)
     {
-        $services = $controllers->getServiceLocator()->get('ServiceManager');
+        $services = $controllers->getServiceLocator()->get(ServiceManager::class);
 
         // For BC, if the ZF\OAuth2\Service\OAuth2Server service returns an
         // OAuth2\Server instance, wrap it in a closure.


### PR DESCRIPTION
This seems to be a reasonable way to call the same functionality without relying on an alias in the service manager. Rather, this calls on the fully qualified class name which appears (at least in my environment) to resolve the 500 internal error when calling OPTIONS on /oauth in apigility.