### PR TITLE
ControllerManager constructor requires an argument

### DIFF
--- a/src/Adapter/IbmDb2Adapter.php
+++ b/src/Adapter/IbmDb2Adapter.php
@@ -164,7 +164,6 @@ class IbmDb2Adapter extends OAuth2Db2
                 $this->config['client_table']
             ));
             $params = compact('clientSecret', 'redirectUri', 'grantTypes', 'scope', 'userId', 'clientId');
-
         } else {
             $stmt = db2_prepare($this->db, sprintf(
                 'INSERT INTO %s (client_id, client_secret, redirect_uri, grant_types, scope, user_id) '
@@ -172,7 +171,6 @@ class IbmDb2Adapter extends OAuth2Db2
                 $this->config['client_table']
             ));
             $params = compact('clientId', 'clientSecret', 'redirectUri', 'grantTypes', 'scope', 'userId');
-
         }
         if (false === $stmt) {
             throw new RuntimeException(db2_stmt_errormsg());

--- a/test/Factory/AuthControllerFactoryTest.php
+++ b/test/Factory/AuthControllerFactoryTest.php
@@ -58,7 +58,7 @@ class AuthControllerFactoryTest extends AbstractHttpControllerTestCase
             ],
         ]);
 
-        $this->controllers = $controllers = new ControllerManager();
+        $this->controllers = $controllers = new ControllerManager(null);
         $controllers->setServiceLocator(new ServiceManager());
         $controllers->getServiceLocator()->setService('ServiceManager', $services);
 


### PR DESCRIPTION
The signature for __construct has changed in ZF2 and the config parameter is required now.