### PR TITLE
[WIP] ZF3 components compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,99 @@
 composer.lock
 vendor
+### OSX template
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Composer template
+composer.phar
+/vendor/
+
+# Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+# composer.lock
+### Windows template
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+.idea

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,15 @@
         "zf2"
     ],
     "repositories": [
-        { "type": "composer", "url": "https://packages.zendframework.com/" }
+        { "type": "composer", "url": "https://packages.zendframework.com/" },
+        {
+            "type": "vcs",
+            "url": "https://github.com/AGmakonts/zf-api-problem.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/AGmakonts/zf-content-negotiation.git"
+        }
     ],
     "extra": {
         "branch-alias": {
@@ -18,28 +26,21 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "bshaffer/oauth2-server-php": "~1.7",
-        "zendframework/zend-crypt": "~2.3",
-        "zendframework/zend-http": "~2.3",
-        "zendframework/zend-mvc": "~2.3",
-        "zendframework/zend-servicemanager": "~2.3",
-        "zfcampus/zf-api-problem": "~1.0",
-        "zfcampus/zf-content-negotiation": "~1.0"
+        "bshaffer/oauth2-server-php": "1.8.*",
+        "zendframework/zend-crypt": "2.6.*",
+        "zendframework/zend-http": "2.5.*",
+        "zendframework/zend-mvc": "3.0.*",
+        "zendframework/zend-servicemanager": "3.1.*",
+        "zfcampus/zf-api-problem": "dev-feature/zf3-support",
+        "zfcampus/zf-content-negotiation": "dev-feature/zf3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7",
+        "phpunit/phpunit": "5.4.*",
         "squizlabs/php_codesniffer": "^2.3.1",
-        "zendframework/zend-config": "~2.3",
-        "zendframework/zend-form": "~2.3",
-        "zendframework/zend-loader": "~2.3",
-        "zendframework/zend-log": "~2.3",
-        "zendframework/zend-modulemanager": "~2.3",
-        "zendframework/zend-serializer": "~2.3",
-        "zendframework/zend-test": "~2.3",
-        "zendframework/zend-authentication": "~2.3",
-        "zendframework/zend-i18n": "~2.3",
-        "zendframework/zend-db": "~2.3",
+        "zendframework/zend-test": "3.0.*",
+        "zendframework/zend-authentication": "2.5.*",
+        "zendframework/zend-i18n": "2.7.*",
+        "zendframework/zend-db": "2.8.*",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {

--- a/src/Factory/AuthControllerFactory.php
+++ b/src/Factory/AuthControllerFactory.php
@@ -6,24 +6,34 @@
 
 namespace ZF\OAuth2\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
 use OAuth2\Server as OAuth2Server;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\OAuth2\Controller\AuthController;
 
 class AuthControllerFactory implements FactoryInterface
 {
     /**
-     * @param ServiceLocatorInterface $controllers
-     * @return AuthController
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
      */
-    public function createService(ServiceLocatorInterface $controllers)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
     {
-        $services = $controllers->getServiceLocator()->get('ServiceManager');
-
         // For BC, if the ZF\OAuth2\Service\OAuth2Server service returns an
         // OAuth2\Server instance, wrap it in a closure.
-        $oauth2ServerFactory = $services->get('ZF\OAuth2\Service\OAuth2Server');
+        $oauth2ServerFactory = $container->get('ZF\OAuth2\Service\OAuth2Server');
         if ($oauth2ServerFactory instanceof OAuth2Server) {
             $oauth2Server = $oauth2ServerFactory;
             $oauth2ServerFactory = function () use ($oauth2Server) {
@@ -33,13 +43,14 @@ class AuthControllerFactory implements FactoryInterface
 
         $authController = new AuthController(
             $oauth2ServerFactory,
-            $services->get('ZF\OAuth2\Provider\UserId')
+            $container->get('ZF\OAuth2\Provider\UserId')
         );
 
-        $config = $services->get('Config');
+        $config = $container->get('Config');
         $authController->setApiProblemErrorResponse((isset($config['zf-oauth2']['api_problem_error_response'])
             && $config['zf-oauth2']['api_problem_error_response'] === true));
 
         return $authController;
     }
+
 }

--- a/src/Factory/IbmDb2AdapterFactory.php
+++ b/src/Factory/IbmDb2AdapterFactory.php
@@ -6,21 +6,32 @@
 
 namespace ZF\OAuth2\Factory;
 
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\OAuth2\Adapter\IbmDb2Adapter;
 use ZF\OAuth2\Controller\Exception;
 
 class IbmDb2AdapterFactory implements FactoryInterface
 {
     /**
-     * @param ServiceLocatorInterface $services
-     * @return IbmDb2Adapter
-     * @throws Exception\RuntimeException
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
      */
-    public function createService(ServiceLocatorInterface $services)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
     {
-        $config = $services->get('Config');
+        $config = $container->get('Config');
 
         if (! isset($config['zf-oauth2']['db']) || empty($config['zf-oauth2']['db'])) {
             throw new Exception\RuntimeException(
@@ -52,4 +63,5 @@ class IbmDb2AdapterFactory implements FactoryInterface
             'driver_options' => $driver_options,
         ], $oauth2ServerConfig);
     }
+
 }

--- a/src/Factory/MongoAdapterFactory.php
+++ b/src/Factory/MongoAdapterFactory.php
@@ -6,8 +6,12 @@
 
 namespace ZF\OAuth2\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
 use MongoClient;
-use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\OAuth2\Adapter\MongoAdapter;
 use ZF\OAuth2\Controller\Exception;
@@ -21,15 +25,24 @@ use ZF\OAuth2\Controller\Exception;
 class MongoAdapterFactory implements FactoryInterface
 {
     /**
-     * @param ServiceLocatorInterface $services
-     * @throws Exception\RuntimeException
-     * @return MongoAdapter
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
      */
-    public function createService(ServiceLocatorInterface $services)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
     {
-        $config  = $services->get('Config');
-        return new MongoAdapter($this->getMongoDb($services), $this->getOauth2ServerConfig($config));
+        $config  = $container->get('Config');
+        return new MongoAdapter($this->getMongoDb($container), $this->getOauth2ServerConfig($config));
     }
+
 
     /**
      * Get the mongo database

--- a/src/Factory/OAuth2ServerFactory.php
+++ b/src/Factory/OAuth2ServerFactory.php
@@ -5,20 +5,33 @@
  */
 namespace ZF\OAuth2\Factory;
 
-use Zend\ServiceManager\FactoryInterface;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class OAuth2ServerFactory implements FactoryInterface
 {
-
     /**
-     * @param ServiceLocatorInterface $services
-     * @return OAuth2\Server
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
      */
-    public function createService(ServiceLocatorInterface $services)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
     {
-        $config = $services->get('Config');
+        $config = $container->get('Config');
         $config = isset($config['zf-oauth2']) ? $config['zf-oauth2'] : [];
-        return new OAuth2ServerInstanceFactory($config, $services);
+        return new OAuth2ServerInstanceFactory($config, $container);
     }
+
 }

--- a/src/Factory/OAuth2ServerInstanceFactory.php
+++ b/src/Factory/OAuth2ServerInstanceFactory.php
@@ -5,6 +5,7 @@
  */
 namespace ZF\OAuth2\Factory;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\OAuth2\Controller\Exception;
 use OAuth2\Server as OAuth2Server;
@@ -33,9 +34,9 @@ class OAuth2ServerInstanceFactory
 
     /**
      * @var array $config Configuration to use when creating the instance.
-     * @var ServiceLocatorInterface $services ServiceLocator for retrieving storage adapters.
+     * @var ContainerInterface $services ServiceLocator for retrieving storage adapters.
      */
-    public function __construct(array $config, ServiceLocatorInterface $services)
+    public function __construct(array $config, ContainerInterface $services)
     {
         $this->config   = $config;
         $this->services = $services;

--- a/src/Factory/PdoAdapterFactory.php
+++ b/src/Factory/PdoAdapterFactory.php
@@ -6,7 +6,11 @@
 
 namespace ZF\OAuth2\Factory;
 
-use Zend\ServiceManager\FactoryInterface;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\OAuth2\Adapter\PdoAdapter;
 use ZF\OAuth2\Controller\Exception;
@@ -14,13 +18,22 @@ use ZF\OAuth2\Controller\Exception;
 class PdoAdapterFactory implements FactoryInterface
 {
     /**
-     * @param ServiceLocatorInterface $services
-     * @throws \ZF\OAuth2\Controller\Exception\RuntimeException
-     * @return \ZF\OAuth2\Adapter\PdoAdapter
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
      */
-    public function createService(ServiceLocatorInterface $services)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
     {
-        $config = $services->get('Config');
+
+        $config = $container->get('Config');
 
         if (!isset($config['zf-oauth2']['db']) || empty($config['zf-oauth2']['db'])) {
             throw new Exception\RuntimeException(
@@ -44,4 +57,5 @@ class PdoAdapterFactory implements FactoryInterface
             'options'  => $options,
         ], $oauth2ServerConfig);
     }
+
 }

--- a/src/Provider/UserId/AuthenticationServiceFactory.php
+++ b/src/Provider/UserId/AuthenticationServiceFactory.php
@@ -6,26 +6,40 @@
 
 namespace ZF\OAuth2\Provider\UserId;
 
-use Zend\ServiceManager\FactoryInterface;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class AuthenticationServiceFactory implements FactoryInterface
 {
     /**
-     * @param ServiceLocatorInterface $services
-     * @return AuthenticationService
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
      */
-    public function createService(ServiceLocatorInterface $services)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = NULL)
     {
-        $config = $services->get('Config');
+        $config = $container->get('Config');
 
-        if ($services->has('Zend\Authentication\AuthenticationService')) {
+        if ($container->has('Zend\Authentication\AuthenticationService')) {
             return new AuthenticationService(
-                $services->get('Zend\Authentication\AuthenticationService'),
+                $container->get('Zend\Authentication\AuthenticationService'),
                 $config
             );
         }
 
         return new AuthenticationService(null, $config);
     }
+
 }

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -51,7 +51,8 @@ class OAuth2ServerFactoryTest extends AbstractHttpControllerTestCase
     public function testExceptionThrownOnMissingStorageClass()
     {
         $this->services->setService('Config', []);
-        $factory = $this->factory->createService($this->services);
+        $smFactory = $this->factory;
+        $factory = $smFactory($this->services, 'OAuth2Server');
         $factory();
     }
 

--- a/test/Factory/PdoAdapterFactoryTest.php
+++ b/test/Factory/PdoAdapterFactoryTest.php
@@ -30,7 +30,8 @@ class PdoAdapterFactoryTest extends AbstractHttpControllerTestCase
     public function testExceptionThrownWhenMissingDbCredentials()
     {
         $this->services->setService('Config', []);
-        $adapter = $this->factory->createService($this->services);
+        $smFactory = $this->factory;
+        $adapter = $smFactory($this->services);
 
         $this->assertInstanceOf('ZF\OAuth2\Adapter\PdoAdapter', $adapter);
     }


### PR DESCRIPTION
I've started to modernize all modules required by Apigility to support newer versions of ZF components.
oauth 2 is another one in the series.

This one is still a WIP because I had problems with fixing data provider errors in tests.


```
1) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\AccessTokenTest::testSetAccessToken is invalid.
Could not find a valid ServiceManager for RoutePluginManager

2) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\AuthorizationCodeTest::testGetAuthorizationCode is invalid.
Could not find a valid ServiceManager for RoutePluginManager

3) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\AuthorizationCodeTest::testSetAuthorizationCode is invalid.
Could not find a valid ServiceManager for RoutePluginManager

4) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\AuthorizationCodeTest::testExpireAccessToken is invalid.
Could not find a valid ServiceManager for RoutePluginManager

5) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientCredentialsTest::testCheckClientCredentials is invalid.
Could not find a valid ServiceManager for RoutePluginManager

6) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientTest::testGetClientDetails is invalid.
Could not find a valid ServiceManager for RoutePluginManager

7) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientTest::testCheckRestrictedGrantType is invalid.
Could not find a valid ServiceManager for RoutePluginManager

8) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientTest::testGetAccessToken is invalid.
Could not find a valid ServiceManager for RoutePluginManager

9) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientTest::testSaveClient is invalid.
Could not find a valid ServiceManager for RoutePluginManager

10) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientTest::testIsPublicClient is invalid.
Could not find a valid ServiceManager for RoutePluginManager

11) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ClientTest::testGetClientScope is invalid.
Could not find a valid ServiceManager for RoutePluginManager

12) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\JwtAccessTokenTest::testJwtWithJti is invalid.
Could not find a valid ServiceManager for RoutePluginManager

13) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\JwtBearerTest::testGetClientKey is invalid.
Could not find a valid ServiceManager for RoutePluginManager

14) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\PublicKeyTest::testSetAccessToken is invalid.
Could not find a valid ServiceManager for RoutePluginManager

15) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\RefreshTokenTest::testSetRefreshToken is invalid.
Could not find a valid ServiceManager for RoutePluginManager

16) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ScopeTest::testScopeExists is invalid.
Could not find a valid ServiceManager for RoutePluginManager

17) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\ScopeTest::testGetDefaultScope is invalid.
Could not find a valid ServiceManager for RoutePluginManager

18) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\UserCredentialsTest::testCheckUserCredentials is invalid.
Could not find a valid ServiceManager for RoutePluginManager

19) Warning
The data provider specified for ZFTest\OAuth2\Adapter\Pdo\UserCredentialsTest::testUserClaims is invalid.
Could not find a valid ServiceManager for RoutePluginManager
```
