### PR TITLE
Allow usage of mongodb extension with MongoAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,16 @@ matrix:
     - php: 7
       env:
         - DEPS=lowest
+        - EXT_MONGODB=true
     - php: 7
       env:
         - DEPS=locked
+        - EXT_MONGODB=true
         - CS_CHECK=true
     - php: 7
       env:
         - DEPS=latest
+        - EXT_MONGODB=true
     - php: hhvm 
       env:
         - DEPS=lowest
@@ -44,6 +47,7 @@ matrix:
         - DEPS=locked
     - php: hhvm 
       env:
+        - EXT_MONGODB=true
         - DEPS=latest
   allow_failures:
     - php: hhvm
@@ -54,17 +58,19 @@ notifications:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - if [[ $TRAVIS_PHP_VERSION == '7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
-  - if [[ $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
-  - if [[ $TRAVIS_PHP_VERSION != '7' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == '7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB == 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $EXT_MONGODB != 'true' && $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongo.so" >> /etc/hhvm/php.ini ; fi
   - travis_retry composer self-update
   - chmod -R +rwX test/TestAsset
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION != '7' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi
+  - if [[ $EXT_MONGODB == 'true' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS
+  - php -m
   - composer show
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS
-  - php -m
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php -m ; fi
   - composer show
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,14 @@ notifications:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - if [[ $TRAVIS_PHP_VERSION == '7' ]]; then echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
+  - if [[ $TRAVIS_PHP_VERSION == 'hhvm' ]]; then echo "extension = mongodb.so" >> /etc/hhvm/php.ini ; fi
+  - if [[ $TRAVIS_PHP_VERSION != '7' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - travis_retry composer self-update
   - chmod -R +rwX test/TestAsset
 
 install:
+  - if [[ $TRAVIS_PHP_VERSION != '7' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then composer require --dev $COMPOSER_ARGS alcaeus/mongo-php-adapter ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS

--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ You can install using:
 $ composer require zfcampus/zf-oauth2
 ```
 
-You should also add the following modules to your application's configuration:
+If you are using ext/mongodb, you will also need to install a compatibility
+package:
+
+```bash
+$ composer require alcaeus/mongo-php-adapter
+```
+
+Finally, you will need to add the following modules to your application's
+configuration:
 
 ```php
 'modules' => [

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
         "zendframework/zend-serializer": "^2.8",
         "zendframework/zend-test": "^2.6.1 || ^3.0.1"
     },
+    "suggest": {
+        "alcaeus/mongo-php-adapter": "^1.0.5, if you are using ext/mongodb and wish to use the MongoAdapter for OAuth2 credential storage."
+    },
     "autoload": {
         "psr-4": {
             "ZF\\OAuth2\\": "src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "79245d982fa13c78378aa62d4d9995c0",
+    "hash": "8b3de83ffe9f5472dde021837257fc13",
     "content-hash": "b30b519e713ba722c3bf7a97a2d4cc17",
     "packages": [
         {

--- a/src/Adapter/MongoAdapter.php
+++ b/src/Adapter/MongoAdapter.php
@@ -89,8 +89,7 @@ class MongoAdapter extends OAuth2Mongo
     public function __construct($connection, $config = [])
     {
         // @codeCoverageIgnoreStart
-        $useMongoDb = version_compare(PHP_VERSION, '7.0', '>=');
-        if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
+        if (! (extension_loaded('mongodb') || extension_loaded('mongo'))
             || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')
         ) {

--- a/src/Adapter/MongoAdapter.php
+++ b/src/Adapter/MongoAdapter.php
@@ -89,7 +89,7 @@ class MongoAdapter extends OAuth2Mongo
     public function __construct($connection, $config = [])
     {
         // @codeCoverageIgnoreStart
-        $useMongoDb = defined('HHVM_VERSION') || version_compare(PHP_VERSION, '7.0', '>=');
+        $useMongoDb = version_compare(PHP_VERSION, '7.0', '>=');
         if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
             || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')

--- a/src/Adapter/MongoAdapter.php
+++ b/src/Adapter/MongoAdapter.php
@@ -89,12 +89,15 @@ class MongoAdapter extends OAuth2Mongo
     public function __construct($connection, $config = [])
     {
         // @codeCoverageIgnoreStart
-        if (!extension_loaded('mongo')
-            || ! class_exists('MongoClient')
+        $useMongoDb = defined('HHVM_VERSION') || version_compare(PHP_VERSION, '7.0', '>=');
+        if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
+            || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')
         ) {
             throw new Exception\RuntimeException(
-                'The Mongo Driver v1.4.1 required for this adapter to work'
+                'The MongoAdapter requires either the Mongo Driver v1.4.1 or '
+                . 'ext/mongodb + the alcaeus/mongo-php-adapter package (which provides '
+                . 'backwards compatibility for ext/mongo classes)'
             );
         }
         // @codeCoverageIgnoreEnd

--- a/test/Controller/AuthControllerWithMongoAdapterTest.php
+++ b/test/Controller/AuthControllerWithMongoAdapterTest.php
@@ -36,7 +36,7 @@ class AuthControllerWithMongoAdapterTest extends AbstractHttpControllerTestCase
 
     public function setUp()
     {
-        $useMongoDb = defined('HHVM_VERSION') || version_compare(PHP_VERSION, '7.0', '>=');
+        $useMongoDb = version_compare(PHP_VERSION, '7.0', '>=');
         if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
             || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')

--- a/test/Controller/AuthControllerWithMongoAdapterTest.php
+++ b/test/Controller/AuthControllerWithMongoAdapterTest.php
@@ -36,8 +36,7 @@ class AuthControllerWithMongoAdapterTest extends AbstractHttpControllerTestCase
 
     public function setUp()
     {
-        $useMongoDb = version_compare(PHP_VERSION, '7.0', '>=');
-        if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
+        if (! (extension_loaded('mongodb') || extension_loaded('mongo'))
             || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')
         ) {

--- a/test/Controller/AuthControllerWithMongoAdapterTest.php
+++ b/test/Controller/AuthControllerWithMongoAdapterTest.php
@@ -6,19 +6,42 @@
 
 namespace ZFTest\OAuth2\Controller;
 
+use MongoClient;
+use MongoConnectionException;
+use MongoDB;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 
 class AuthControllerWithMongoAdapterTest extends AbstractHttpControllerTestCase
 {
     /**
-     * @var \MongoDB
+     * @var MongoDB
      */
     protected $db;
 
+    /**
+     * Default data to insert in database.
+     *
+     * Defined here to prevent "cannot pass by reference" issues when using
+     * alcaeus/mongo-php-adapter (as that library accepts a reference for the
+     * first argument, and unassigned arrays fail that).
+     *
+     * @var array
+     */
+    protected $defaultData = [
+        'client_id'     => 'testclient',
+        'client_secret' => '$2y$14$f3qml4G2hG6sxM26VMq.geDYbsS089IBtVJ7DlD05BoViS9PFykE2',
+        'redirect_uri'  => '/oauth/receivecode',
+        'grant_types'   => null,
+    ];
+
     public function setUp()
     {
-        if (!extension_loaded('mongo')) {
-            $this->markTestSkipped('The Mongo extension is not available.');
+        $useMongoDb = defined('HHVM_VERSION') || version_compare(PHP_VERSION, '7.0', '>=');
+        if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
+            || ! class_exists(MongoClient::class)
+            || version_compare(MongoClient::VERSION, '1.4.1', '<')
+        ) {
+            $this->markTestSkipped('ext/mongo ^1.4.1 or ext/mongodb + alcaeus/mongo-php-adapter is not available.');
         }
 
         $this->setApplicationConfig(include __DIR__ . '/../TestAsset/mongo.application.config.php');
@@ -26,24 +49,20 @@ class AuthControllerWithMongoAdapterTest extends AbstractHttpControllerTestCase
         parent::setUp();
 
         try {
-            $client = new \MongoClient("mongodb://127.0.0.1:27017");
-        } catch (\MongoConnectionException $e) {
+            $client = new MongoClient("mongodb://127.0.0.1:27017");
+        } catch (MongoConnectionException $e) {
             $this->markTestSkipped($e->getMessage());
         }
+
         $this->db = $client->selectDB('zf_oauth2_test');
-        $this->db->oauth_clients->insert([
-            'client_id'     => 'testclient',
-            'client_secret' => '$2y$14$f3qml4G2hG6sxM26VMq.geDYbsS089IBtVJ7DlD05BoViS9PFykE2',
-            'redirect_uri'  => '/oauth/receivecode',
-            'grant_types'   => null
-        ]);
+        $this->db->oauth_clients->insert($this->defaultData);
 
         $this->getApplicationServiceLocator()->setService('MongoDB', $this->db);
     }
 
     public function tearDown()
     {
-        if ($this->db instanceof \MongoDB) {
+        if ($this->db instanceof MongoDB) {
             $this->db->drop();
         }
 

--- a/test/Factory/MongoAdapterFactoryTest.php
+++ b/test/Factory/MongoAdapterFactoryTest.php
@@ -27,7 +27,7 @@ class MongoAdapterFactoryTest extends AbstractHttpControllerTestCase
 
     protected function setUp()
     {
-        $useMongoDb = defined('HHVM_VERSION') || version_compare(PHP_VERSION, '7.0', '>=');
+        $useMongoDb = version_compare(PHP_VERSION, '7.0', '>=');
         if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
             || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')

--- a/test/Factory/MongoAdapterFactoryTest.php
+++ b/test/Factory/MongoAdapterFactoryTest.php
@@ -6,6 +6,8 @@
 
 namespace ZFTest\OAuth2\Factory;
 
+use MongoClient;
+use MongoDB;
 use ReflectionObject;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
@@ -25,8 +27,12 @@ class MongoAdapterFactoryTest extends AbstractHttpControllerTestCase
 
     protected function setUp()
     {
-        if (!extension_loaded('mongo')) {
-            $this->markTestSkipped('The Mongo extension is not available.');
+        $useMongoDb = defined('HHVM_VERSION') || version_compare(PHP_VERSION, '7.0', '>=');
+        if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
+            || ! class_exists(MongoClient::class)
+            || version_compare(MongoClient::VERSION, '1.4.1', '<')
+        ) {
+            $this->markTestSkipped('ext/mongo or ext/mongodb + alcaeus/mongo-php-adapter is not available.');
         }
 
         $this->factory  = new MongoAdapterFactory();
@@ -81,7 +87,9 @@ class MongoAdapterFactoryTest extends AbstractHttpControllerTestCase
                 ],
             ],
         ]);
-        $mock = $this->getMock('\MongoDB', [], [], '', false);
+        $mock = $this->getMockBuilder(MongoDB::class, [], [], '', false)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->services->setService('testdb', $mock);
 
         $adapter = $this->factory->createService($this->services);
@@ -100,7 +108,9 @@ class MongoAdapterFactoryTest extends AbstractHttpControllerTestCase
                 ],
             ],
         ]);
-        $mock = $this->getMock('\MongoDB', [], [], '', false);
+        $mock = $this->getMockBuilder(MongoDB::class, [], [], '', false)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->services->setService('testdb', $mock);
 
         $adapter = $this->factory->createService($this->services);

--- a/test/Factory/MongoAdapterFactoryTest.php
+++ b/test/Factory/MongoAdapterFactoryTest.php
@@ -27,8 +27,7 @@ class MongoAdapterFactoryTest extends AbstractHttpControllerTestCase
 
     protected function setUp()
     {
-        $useMongoDb = version_compare(PHP_VERSION, '7.0', '>=');
-        if (! extension_loaded($useMongoDb ? 'mongodb' : 'mongo')
+        if (! (extension_loaded('mongodb') || extension_loaded('mongo'))
             || ! class_exists(MongoClient::class)
             || version_compare(MongoClient::VERSION, '1.4.1', '<')
         ) {

--- a/test/TestAsset/mongo.application.config.php
+++ b/test/TestAsset/mongo.application.config.php
@@ -1,28 +1,33 @@
 <?php
-return array(
+$modules = [
+    'ZF\ContentNegotiation',
+    'ZF\OAuth2',
+];
+
+if (class_exists('Zend\Router\Module')) {
+    $modules[] = 'Zend\Router';
+}
+
+return [
     // This should be an array of module namespaces used in the application.
-    'modules' => array(
-        'ZF\ContentNegotiation',
-        'ZF\OAuth2'
-    ),
+    'modules' => $modules,
 
     // These are various options for the listeners attached to the ModuleManager
-    'module_listener_options' => array(
+    'module_listener_options' => [
         // This should be an array of paths in which modules reside.
         // If a string key is provided, the listener will consider that a module
         // namespace, the value of that key the specific path to that module's
         // Module class.
-        'module_paths' => array(
+        'module_paths' => [
             __DIR__ . '/../../../../..',
             __DIR__ . '/../../../../../vendor',
-        ),
+        ],
 
         // An array of paths from which to glob configuration files after
         // modules are loaded. These effectively override configuration
         // provided by modules themselves. Paths may use GLOB_BRACE notation.
-        'config_glob_paths' => array(
+        'config_glob_paths' => [
             __DIR__ . '/autoload_mongo/{,*.}{global,local}.php',
-        ),
-
-    ),
-);
+        ],
+    ],
+];


### PR DESCRIPTION
This patch addresses #138 and #145, with the following approach:

- alcaeus/mongo-php-adapter is suggested when using PHP 7 or ext/mongodb. It is not required by default, as installing it conflicts with ext/mongo.
- In classes that use `MongoClient`, tests are done for:
  - Presence of either ext/mongo or ext/mongodb
  - Presence of the MongoClient class
  - MongoClient >= 1.4.1
- Travis CI is setup to enable ext/mongodb when testing against hhvm or PHP 7, and ext/mongo for all other versions. When ext/mongodb is installed, it also adds alcaeus/mongo-php-adapter as a development requirement.
- Updates the `mongo.application.config.php` test asset to add `Zend\Router` as a module when it is present.

Tests now pass against all versions.