### PR TITLE
Changed to short array notation

### DIFF
--- a/config/oauth2.local.php.dist
+++ b/config/oauth2.local.php.dist
@@ -1,14 +1,14 @@
 <?php
-return array(
-    'zf-oauth2' => array(
-        'db' => array(
+return [
+    'zf-oauth2' => [
+        'db' => [
             'dsn'      => 'insert here the DSN for DB connection', // for example "mysql:dbname=oauth2_db;host=localhost"
             'username' => 'insert here the DB username',
             'password' => 'insert here the DB password',
-        ),
+        ],
         'allow_implicit' => false, // default (set to true when you need to support browser-based or mobile apps)
         'access_lifetime' => 3600, // default (set a value in seconds for access tokens lifetime)
         'enforce_state'  => true,  // default
         'storage'        => 'ZF\OAuth2\Adapter\PdoAdapter', // service name for the OAuth2 storage adapter
-    ),
-);
+    ],
+];


### PR DESCRIPTION
As the module config is in short array notation as well the list can be in short array notation. Supporting the composer dependancy of ```^5.6 || ^7.0```