### PR TITLE
Include all server options in config file

### DIFF
--- a/config/oauth2.local.php.dist
+++ b/config/oauth2.local.php.dist
@@ -6,9 +6,31 @@ return [
             'username' => 'insert here the DB username',
             'password' => 'insert here the DB password',
         ],
-        'allow_implicit' => false, // default (set to true when you need to support browser-based or mobile apps)
+        'storage' => 'ZF\OAuth2\Adapter\PdoAdapter', // service name for the OAuth2 storage adapter
+
+        /**
+         * These special OAuth2Server options are parsed outside the options array
+         */
+        'allow_implicit'  => false, // default (set to true when you need to support browser-based or mobile apps)
         'access_lifetime' => 3600, // default (set a value in seconds for access tokens lifetime)
-        'enforce_state'  => true,  // default
-        'storage'        => 'ZF\OAuth2\Adapter\PdoAdapter', // service name for the OAuth2 storage adapter
+        'enforce_state'   => true,  // default
+
+        /**
+         * These are all OAuth2Server options with their default values
+         */
+        'options' => [
+            'use_jwt_access_tokens'             => false,
+            'store_encrypted_token_string'      => true,
+            'use_openid_connect'                => false,
+            'id_lifetime'                       => 3600,
+            'www_realm'                         => 'Service',
+            'token_param_name'                  => 'access_token',
+            'token_bearer_header_name'          => 'Bearer',
+            'require_exact_redirect_uri'        => true,
+            'allow_credentials_in_request_body' => true,
+            'allow_public_clients'              => true,
+            'always_issue_new_refresh_token'    => false,
+            'unset_refresh_token_after_use'     => true,
+        ],
     ],
 ];


### PR DESCRIPTION
The only way to learn all the possible server options is via bshaffer's OAuth2 server code base.  This PR puts all possible options into the **correct** place in the config file.

This solves the problem of config options not knowing where they belong...there is nothing to tell you most of these belong in the `options` array.