### PR TITLE
Add missing start paragraph tag

### DIFF
--- a/view/zf/auth/receive-code.phtml
+++ b/view/zf/auth/receive-code.phtml
@@ -2,7 +2,7 @@
 if ($this->code) {
     printf("<h2>The authentication code is %s</h2>", $this->code);
     printf("<p>Use this code to request an access token.</p>");
-    printf("For instance, using <a href=\"https://github.com/jkbr/httpie\">HTTPie</a>:</p> ");
+    printf("<p>For instance, using <a href=\"https://github.com/jkbr/httpie\">HTTPie</a>:</p> ");
     printf(
         "<p>http POST %s grant_type=authorization_code code=%s redirect_uri=%s client_id=testclient client_secret=testpass</p>",
         $this->serverUrl('/oauth'),


### PR DESCRIPTION
Add missing start paragraph tag to the example link in the receive-code view template file so that the resulting HTML is well-structured again
